### PR TITLE
Load settings from config file

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,19 +62,77 @@ go install github.com/oz/tz@latest
 
 The tz program uses standard time zones as described
 [here](https://en.wikipedia.org/wiki/List_of_tz_database_time_zones).
-You should specify what time zones to display by setting the `TZ_LIST`
-environment variable. The local time is always displayed first. To
-display your local time, the time in California, and the time Paris, you
-have to set `TZ_LIST` to `US/Pacific;Europe/Paris`
 
-## Zone Alias
+You can specify preferences through a configuration file, an environment variable,
+or as command arguments.
 
-The `TZ_LIST` env. variable recognizes items from the standard tz
+They are applied in this order, overriding at each subsequent step:
+
+1. Configuration file `~/.config/tz/conf.toml`
+2. Environment variable `TZ_LIST`
+3. Command line arguments `tz UTC`
+
+The local time zone is always displayed first.
+
+## Configuration File
+
+Configs are read from `$HOME/.config/tz/conf.toml`.
+
+Time zone `id`s should reference items from the standard tz database names.
+Alias them by providing your own name with the `name` key.
+
+Sample configuration:
+
+```toml
+[[zones]]
+id = "NZ"
+name = "NZ"
+
+[[zones]]
+id = "Australia/Sydney"
+name = "Sydney"
+
+[[zones]]
+id = "Asia/Kolkata"
+name = "Bangalore"
+
+[[zones]]
+id = "UTC"
+name = "UTC"
+
+[keymaps]
+prev_hour = ["h", "left"]
+next_hour = ["l", "right"]
+prev_day = ["k", "up"]
+next_day = ["j", "down"]
+prev_week = ["p", "<"]
+next_week = ["n", ">"]
+toggle_date = ["d"]
+open_web = ["o", "x"]
+now = ["t"]
+```
+
+## Environment Variable
+
+This method only supports setting time zones. Keymaps must be configured through
+the configuration file.
+
+Specify time zones to display by setting the `TZ_LIST` environment variable. For
+example, to display your local time, the time in California, and the time Paris,
+set `TZ_LIST` to `US/Pacific;Europe/Paris`.
+
+The `TZ_LIST` environment variable recognizes items from the standard tz
 database names, but you can alias these, using a special value: use the
 standard name followed by `,` and your alias. For example:
 
-```
+```bash
 TZ_LIST="Europe/Paris,EMEA office;US/Central,US office"
+```
+
+If adding this to a shell configuration, remember to export it:
+
+```bash
+export TZ_LIST="Europe/Paris,EMEA office;US/Central,US office"
 ```
 
 
@@ -82,7 +140,7 @@ TZ_LIST="Europe/Paris,EMEA office;US/Central,US office"
 
 You need a recent-ish release of go with modules support:
 
-```
+```bash
 git clone https://github.com/oz/tz
 cd tz
 go build
@@ -91,8 +149,15 @@ go build
 
 # Testing
 
-```
+```bash
 go test -cover
+```
+
+
+# Debug
+
+```bash
+DEBUG=1 tz # Logs will write to debug.log
 ```
 
 

--- a/config.go
+++ b/config.go
@@ -16,76 +16,21 @@
  **/
 package main
 
-import (
-	"fmt"
-	"os"
-	"strings"
-	"time"
-)
+// Keymaps represents the key mappings in the TOML file
+type Keymaps struct {
+	PrevHour   []string
+	NextHour   []string
+	PrevDay    []string
+	NextDay    []string
+	PrevWeek   []string
+	NextWeek   []string
+	ToggleDate []string
+	OpenWeb    []string
+	Now        []string
+}
 
 // Config stores app configuration
 type Config struct {
-	Zones []*Zone
-}
-
-// LoadConfig from environment
-func LoadConfig(tzConfigs []string) (*Config, error) {
-	conf := Config{
-		Zones: DefaultZones,
-	}
-
-	if len(tzConfigs) == 0 {
-		tzList := os.Getenv("TZ_LIST")
-		if tzList == "" {
-			return &conf, nil
-		}
-		tzConfigs = strings.Split(tzList, ";")
-		if len(tzConfigs) == 0 {
-			return &conf, nil
-		}
-	}
-	zones := make([]*Zone, len(tzConfigs)+1)
-
-	// Setup with Local time zone
-	localZoneName, _ := time.Now().Zone()
-	zones[0] = &Zone{
-		Name:   fmt.Sprintf("(%s) Local", localZoneName),
-		DbName: localZoneName,
-	}
-
-	// Add zones from TZ_LIST
-	for i, zoneConf := range tzConfigs {
-		zone, err := SetupZone(time.Now(), zoneConf)
-		if err != nil {
-			return nil, err
-		}
-		zones[i+1] = zone
-	}
-	conf.Zones = zones
-
-	return &conf, nil
-}
-
-// SetupZone from current time and a zoneConf string
-func SetupZone(now time.Time, zoneConf string) (*Zone, error) {
-	names := strings.Split(zoneConf, ",")
-	dbName := strings.Trim(names[0], " ")
-	var name string
-	if len(names) == 2 {
-		name = names[1]
-	}
-
-	loc, err := time.LoadLocation(dbName)
-	if err != nil {
-		return nil, fmt.Errorf("looking up zone %s: %w", dbName, err)
-	}
-	if name == "" {
-		name = loc.String()
-	}
-	then := now.In(loc)
-	shortName, _ := then.Zone()
-	return &Zone{
-		DbName: loc.String(),
-		Name:   fmt.Sprintf("(%s) %s", shortName, name),
-	}, nil
+	Zones   []*Zone
+	Keymaps Keymaps
 }

--- a/config.go
+++ b/config.go
@@ -71,6 +71,10 @@ func LoadConfig(tzConfigs []string) (Config, error) {
 		mergedConfig.Zones = fileConfig.Zones
 	}
 
+	logger.Printf("File config: %s", fileConfig.Zones)
+	logger.Printf("Env config: %s", envConfig.Zones)
+	logger.Printf("Merged config: %s", mergedConfig.Zones)
+
 	// Merge Keymaps
 	if len(fileConfig.Keymaps.PrevHour) > 0 {
 		mergedConfig.Keymaps.PrevHour = fileConfig.Keymaps.PrevHour

--- a/config.go
+++ b/config.go
@@ -34,3 +34,79 @@ type Config struct {
 	Zones   []*Zone
 	Keymaps Keymaps
 }
+
+// Function to provide default values for the Config struct
+func NewDefaultConfig() Config {
+	return Config{
+		Zones: []*Zone{}, // Default to an empty slice of Zones
+		Keymaps: Keymaps{
+			PrevHour:   []string{"h", "left"},
+			NextHour:   []string{"l", "right"},
+			PrevDay:    []string{"k", "up"},
+			NextDay:    []string{"j", "down"},
+			PrevWeek:   []string{"p"},
+			NextWeek:   []string{"n"},
+			ToggleDate: []string{"d"},
+			OpenWeb:    []string{"o"},
+			Now:        []string{"t"},
+		},
+	}
+}
+
+func LoadConfig(tzConfigs []string) (Config, error) {
+
+	// Apply config file first
+	fileConfig, _ := LoadConfigFile()
+
+	// Override with env var config
+	envConfig, _ := LoadConfigEnv(tzConfigs)
+
+	// Merge configs, with envConfig taking precedence
+	mergedConfig := NewDefaultConfig()
+
+	// Merge Zones
+	if len(envConfig.Zones) > 0 {
+		mergedConfig.Zones = envConfig.Zones
+	} else if len(fileConfig.Zones) > 0 {
+		mergedConfig.Zones = fileConfig.Zones
+	}
+
+	// Merge Keymaps
+	if len(fileConfig.Keymaps.PrevHour) > 0 {
+		mergedConfig.Keymaps.PrevHour = fileConfig.Keymaps.PrevHour
+	}
+
+	if len(fileConfig.Keymaps.NextHour) > 0 {
+		mergedConfig.Keymaps.NextHour = fileConfig.Keymaps.NextHour
+	}
+
+	if len(fileConfig.Keymaps.PrevDay) > 0 {
+		mergedConfig.Keymaps.PrevDay = fileConfig.Keymaps.PrevDay
+	}
+
+	if len(fileConfig.Keymaps.NextDay) > 0 {
+		mergedConfig.Keymaps.NextDay = fileConfig.Keymaps.NextDay
+	}
+
+	if len(fileConfig.Keymaps.PrevWeek) > 0 {
+		mergedConfig.Keymaps.PrevWeek = fileConfig.Keymaps.PrevWeek
+	}
+
+	if len(fileConfig.Keymaps.NextWeek) > 0 {
+		mergedConfig.Keymaps.NextWeek = fileConfig.Keymaps.NextWeek
+	}
+
+	if len(fileConfig.Keymaps.ToggleDate) > 0 {
+		mergedConfig.Keymaps.ToggleDate = fileConfig.Keymaps.ToggleDate
+	}
+
+	if len(fileConfig.Keymaps.OpenWeb) > 0 {
+		mergedConfig.Keymaps.OpenWeb = fileConfig.Keymaps.OpenWeb
+	}
+
+	if len(fileConfig.Keymaps.Now) > 0 {
+		mergedConfig.Keymaps.Now = fileConfig.Keymaps.Now
+	}
+
+	return mergedConfig, nil
+}

--- a/config_env.go
+++ b/config_env.go
@@ -25,9 +25,7 @@ import (
 
 // LoadConfigEnv from environment
 func LoadConfigEnv(tzConfigs []string) (*Config, error) {
-	conf := Config{
-		Zones: DefaultZones,
-	}
+	conf := Config{}
 
 	if len(tzConfigs) == 0 {
 		tzList := os.Getenv("TZ_LIST")
@@ -39,14 +37,7 @@ func LoadConfigEnv(tzConfigs []string) (*Config, error) {
 			return &conf, nil
 		}
 	}
-	zones := make([]*Zone, len(tzConfigs)+1)
-
-	// Setup with Local time zone
-	localZoneName, _ := time.Now().Zone()
-	zones[0] = &Zone{
-		Name:   fmt.Sprintf("(%s) Local", localZoneName),
-		DbName: localZoneName,
-	}
+	zones := make([]*Zone, len(tzConfigs))
 
 	// Add zones from TZ_LIST
 	for i, zoneConf := range tzConfigs {
@@ -54,7 +45,7 @@ func LoadConfigEnv(tzConfigs []string) (*Config, error) {
 		if err != nil {
 			return nil, err
 		}
-		zones[i+1] = zone
+		zones[i] = zone
 	}
 	conf.Zones = zones
 

--- a/config_env.go
+++ b/config_env.go
@@ -23,8 +23,8 @@ import (
 	"time"
 )
 
-// LoadConfig from environment
-func LoadConfig(tzConfigs []string) (*Config, error) {
+// LoadConfigEnv from environment
+func LoadConfigEnv(tzConfigs []string) (*Config, error) {
 	conf := Config{
 		Zones: DefaultZones,
 	}
@@ -50,7 +50,7 @@ func LoadConfig(tzConfigs []string) (*Config, error) {
 
 	// Add zones from TZ_LIST
 	for i, zoneConf := range tzConfigs {
-		zone, err := SetupZone(time.Now(), zoneConf)
+		zone, err := ReadZoneFromString(time.Now(), zoneConf)
 		if err != nil {
 			return nil, err
 		}
@@ -61,8 +61,8 @@ func LoadConfig(tzConfigs []string) (*Config, error) {
 	return &conf, nil
 }
 
-// SetupZone from current time and a zoneConf string
-func SetupZone(now time.Time, zoneConf string) (*Zone, error) {
+// ReadZoneFromString from current time and a zoneConf string
+func ReadZoneFromString(now time.Time, zoneConf string) (*Zone, error) {
 	names := strings.Split(zoneConf, ",")
 	dbName := strings.Trim(names[0], " ")
 	var name string

--- a/config_env.go
+++ b/config_env.go
@@ -1,0 +1,86 @@
+/**
+ * This file is part of tz.
+ *
+ * tz is free software: you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free
+ * Software Foundation, either version 3 of the License, or (at your
+ * option) any later version.
+ *
+ * tz is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY
+ * or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public
+ * License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with tz.  If not, see <https://www.gnu.org/licenses/>.
+ **/
+package main
+
+import (
+	"fmt"
+	"os"
+	"strings"
+	"time"
+)
+
+// LoadConfig from environment
+func LoadConfig(tzConfigs []string) (*Config, error) {
+	conf := Config{
+		Zones: DefaultZones,
+	}
+
+	if len(tzConfigs) == 0 {
+		tzList := os.Getenv("TZ_LIST")
+		if tzList == "" {
+			return &conf, nil
+		}
+		tzConfigs = strings.Split(tzList, ";")
+		if len(tzConfigs) == 0 {
+			return &conf, nil
+		}
+	}
+	zones := make([]*Zone, len(tzConfigs)+1)
+
+	// Setup with Local time zone
+	localZoneName, _ := time.Now().Zone()
+	zones[0] = &Zone{
+		Name:   fmt.Sprintf("(%s) Local", localZoneName),
+		DbName: localZoneName,
+	}
+
+	// Add zones from TZ_LIST
+	for i, zoneConf := range tzConfigs {
+		zone, err := SetupZone(time.Now(), zoneConf)
+		if err != nil {
+			return nil, err
+		}
+		zones[i+1] = zone
+	}
+	conf.Zones = zones
+
+	return &conf, nil
+}
+
+// SetupZone from current time and a zoneConf string
+func SetupZone(now time.Time, zoneConf string) (*Zone, error) {
+	names := strings.Split(zoneConf, ",")
+	dbName := strings.Trim(names[0], " ")
+	var name string
+	if len(names) == 2 {
+		name = names[1]
+	}
+
+	loc, err := time.LoadLocation(dbName)
+	if err != nil {
+		return nil, fmt.Errorf("looking up zone %s: %w", dbName, err)
+	}
+	if name == "" {
+		name = loc.String()
+	}
+	then := now.In(loc)
+	shortName, _ := then.Zone()
+	return &Zone{
+		DbName: loc.String(),
+		Name:   fmt.Sprintf("(%s) %s", shortName, name),
+	}, nil
+}

--- a/config_file.go
+++ b/config_file.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"fmt"
+	"log"
 	"os"
 	"path/filepath"
 	"time"
@@ -72,6 +73,7 @@ func LoadConfigFile() (*Config, error) {
 	configFile, err := os.ReadFile(configFilePath)
 	if err != nil {
 		// Silently return
+		logger.Println("Config file '~/.config/tz/conf.toml' not found. Skipping...")
 		return &conf, nil
 	}
 
@@ -79,6 +81,7 @@ func LoadConfigFile() (*Config, error) {
 	var config ConfigFile
 	err = toml.Unmarshal(configFile, &config)
 	if err != nil {
+		log.Panicf("Error parsing config file %s \n %v", configFilePath, err)
 		panic(err)
 	}
 

--- a/config_file.go
+++ b/config_file.go
@@ -62,7 +62,8 @@ func LoadConfigFile() (*Config, error) {
 	// Expand the ~ to the home directory
 	homeDir, err := os.UserHomeDir()
 	if err != nil {
-		panic(err)
+		// Silently return
+		return &conf, nil
 	}
 
 	configFilePath := filepath.Join(homeDir, ".config", "tz", "conf.toml")
@@ -70,7 +71,8 @@ func LoadConfigFile() (*Config, error) {
 	// Read the TOML file
 	configFile, err := os.ReadFile(configFilePath)
 	if err != nil {
-		panic(err)
+		// Silently return
+		return &conf, nil
 	}
 
 	// Unmarshal the TOML data into the Config struct

--- a/config_file.go
+++ b/config_file.go
@@ -80,13 +80,6 @@ func LoadConfigFile() (*Config, error) {
 		panic(err)
 	}
 
-	// Use the config values
-	fmt.Printf("Header: %s\n", config.Header)
-	fmt.Println("Zones:")
-	for _, zone := range config.Zones {
-		fmt.Printf("  ID: %s, Name: %s\n", zone.ID, zone.Name)
-	}
-
 	zones := make([]*Zone, len(config.Zones)+1)
 
 	// Setup with Local time zone

--- a/config_file.go
+++ b/config_file.go
@@ -56,9 +56,7 @@ func ReadZonesFromFile(now time.Time, zoneConf ConfigFileZone) (*Zone, error) {
 }
 
 func LoadConfigFile() (*Config, error) {
-	conf := Config{
-		Zones: DefaultZones,
-	}
+	conf := Config{}
 
 	// Expand the ~ to the home directory
 	homeDir, err := os.UserHomeDir()
@@ -85,14 +83,7 @@ func LoadConfigFile() (*Config, error) {
 		panic(err)
 	}
 
-	zones := make([]*Zone, len(config.Zones)+1)
-
-	// Setup with Local time zone
-	localZoneName, _ := time.Now().Zone()
-	zones[0] = &Zone{
-		Name:   fmt.Sprintf("(%s) Local", localZoneName),
-		DbName: localZoneName,
-	}
+	zones := make([]*Zone, len(config.Zones))
 
 	// Add zones from config file
 	for i, zoneConf := range config.Zones {
@@ -100,7 +91,7 @@ func LoadConfigFile() (*Config, error) {
 		if err != nil {
 			return nil, err
 		}
-		zones[i+1] = zone
+		zones[i] = zone
 	}
 
 	conf.Zones = zones

--- a/config_file.go
+++ b/config_file.go
@@ -104,7 +104,9 @@ func LoadConfigFile() (*Config, error) {
 		}
 		zones[i+1] = zone
 	}
+
 	conf.Zones = zones
+	conf.Keymaps = Keymaps(config.Keymaps)
 
 	return &conf, nil
 }

--- a/config_file.go
+++ b/config_file.go
@@ -35,7 +35,7 @@ type ConfigFileKeymaps struct {
 	Now        []string `toml:"now"`
 }
 
-func setupZone(now time.Time, zoneConf ConfigFileZone) (*Zone, error) {
+func ReadZonesFromFile(now time.Time, zoneConf ConfigFileZone) (*Zone, error) {
 	name := zoneConf.Name
 	dbName := zoneConf.ID
 
@@ -91,7 +91,7 @@ func LoadConfigFile() (*Config, error) {
 
 	// Add zones from config file
 	for i, zoneConf := range config.Zones {
-		zone, err := setupZone(time.Now(), zoneConf)
+		zone, err := ReadZonesFromFile(time.Now(), zoneConf)
 		if err != nil {
 			return nil, err
 		}

--- a/config_file.go
+++ b/config_file.go
@@ -1,0 +1,110 @@
+package main
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"time"
+
+	"github.com/pelletier/go-toml/v2"
+)
+
+// Config represents the entire TOML configuration
+type ConfigFile struct {
+	Header  string            `toml:"header"`
+	Zones   []ConfigFileZone  `toml:"zones"`
+	Keymaps ConfigFileKeymaps `toml:"keymaps"`
+}
+
+// Zone represents a single zone entry in the TOML file
+type ConfigFileZone struct {
+	ID   string `toml:"id"`
+	Name string `toml:"name"`
+}
+
+// Keymaps represents the key mappings in the TOML file
+type ConfigFileKeymaps struct {
+	PrevHour   []string `toml:"prev_hour"`
+	NextHour   []string `toml:"next_hour"`
+	PrevDay    []string `toml:"prev_day"`
+	NextDay    []string `toml:"next_day"`
+	PrevWeek   []string `toml:"prev_week"`
+	NextWeek   []string `toml:"next_week"`
+	ToggleDate []string `toml:"toggle_date"`
+	OpenWeb    []string `toml:"open_web"`
+	Now        []string `toml:"now"`
+}
+
+func setupZone(now time.Time, zoneConf ConfigFileZone) (*Zone, error) {
+	name := zoneConf.Name
+	dbName := zoneConf.ID
+
+	loc, err := time.LoadLocation(dbName)
+	if err != nil {
+		return nil, fmt.Errorf("looking up zone %s: %w", dbName, err)
+	}
+	if name == "" {
+		name = loc.String()
+	}
+	then := now.In(loc)
+	shortName, _ := then.Zone()
+	return &Zone{
+		DbName: loc.String(),
+		Name:   fmt.Sprintf("(%s) %s", shortName, name),
+	}, nil
+}
+
+func LoadConfigFile() (*Config, error) {
+	conf := Config{
+		Zones: DefaultZones,
+	}
+
+	// Expand the ~ to the home directory
+	homeDir, err := os.UserHomeDir()
+	if err != nil {
+		panic(err)
+	}
+
+	configFilePath := filepath.Join(homeDir, ".config", "tz", "conf.toml")
+
+	// Read the TOML file
+	configFile, err := os.ReadFile(configFilePath)
+	if err != nil {
+		panic(err)
+	}
+
+	// Unmarshal the TOML data into the Config struct
+	var config ConfigFile
+	err = toml.Unmarshal(configFile, &config)
+	if err != nil {
+		panic(err)
+	}
+
+	// Use the config values
+	fmt.Printf("Header: %s\n", config.Header)
+	fmt.Println("Zones:")
+	for _, zone := range config.Zones {
+		fmt.Printf("  ID: %s, Name: %s\n", zone.ID, zone.Name)
+	}
+
+	zones := make([]*Zone, len(config.Zones)+1)
+
+	// Setup with Local time zone
+	localZoneName, _ := time.Now().Zone()
+	zones[0] = &Zone{
+		Name:   fmt.Sprintf("(%s) Local", localZoneName),
+		DbName: localZoneName,
+	}
+
+	// Add zones from config file
+	for i, zoneConf := range config.Zones {
+		zone, err := setupZone(time.Now(), zoneConf)
+		if err != nil {
+			return nil, err
+		}
+		zones[i+1] = zone
+	}
+	conf.Zones = zones
+
+	return &conf, nil
+}

--- a/config_test.go
+++ b/config_test.go
@@ -44,7 +44,7 @@ func TestSetupZone(t *testing.T) {
 		},
 	}
 	for _, test := range tests {
-		_, err := SetupZone(now, test.zoneName)
+		_, err := ReadZoneFromString(now, test.zoneName)
 		if test.ok != (err == nil) {
 			t.Errorf("Expected %v, but got: %v", test.ok, err)
 		}
@@ -76,7 +76,7 @@ func TestSetupZoneWithCustomNames(t *testing.T) {
 		},
 	}
 	for _, test := range tests {
-		z, err := SetupZone(now, test.zoneName)
+		z, err := ReadZoneFromString(now, test.zoneName)
 		if test.ok != (err == nil) {
 			t.Errorf("Expected %v, but got: %v", test.ok, err)
 		}

--- a/example-conf.toml
+++ b/example-conf.toml
@@ -1,5 +1,3 @@
-header = "What time is it?"
-
 [[zones]]
 id = "NZ"
 name = "NZ"

--- a/example-conf.toml
+++ b/example-conf.toml
@@ -17,13 +17,12 @@ id = "UTC"
 name = "UTC"
 
 [keymaps]
-prev_hour = ["h"]
-next_hour = ["l"]
-prev_day = ["k"]
-next_day = ["j"]
+prev_hour = ["h", "left"]
+next_hour = ["l", "right"]
+prev_day = ["k", "up"]
+next_day = ["j", "down"]
 prev_week = ["p"]
 next_week = ["n"]
 toggle_date = ["d"]
 open_web = ["o"]
 now = ["t"]
-

--- a/example-conf.toml
+++ b/example-conf.toml
@@ -1,0 +1,29 @@
+header = "What time is it?"
+
+[[zones]]
+id = "NZ"
+name = "NZ"
+
+[[zones]]
+id = "Australia/Sydney"
+name = "Sydney"
+
+[[zones]]
+id = "Asia/Kolkata"
+name = "Bangalore"
+
+[[zones]]
+id = "UTC"
+name = "UTC"
+
+[keymaps]
+prev_hour = ["h"]
+next_hour = ["l"]
+prev_day = ["k"]
+next_day = ["j"]
+prev_week = ["p"]
+next_week = ["n"]
+toggle_date = ["d"]
+open_web = ["o"]
+now = ["t"]
+

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,8 @@
 module github.com/oz/tz
 
-go 1.17
+go 1.21.0
+
+toolchain go1.23.0
 
 require (
 	github.com/charmbracelet/bubbletea v0.22.1
@@ -17,6 +19,7 @@ require (
 	github.com/muesli/ansi v0.0.0-20211031195517-c9f0611b6c70 // indirect
 	github.com/muesli/cancelreader v0.2.2 // indirect
 	github.com/muesli/reflow v0.3.0 // indirect
+	github.com/pelletier/go-toml/v2 v2.2.3 // indirect
 	github.com/rivo/uniseg v0.3.4 // indirect
 	golang.org/x/sys v0.6.0 // indirect
 	golang.org/x/term v0.0.0-20220722155259-a9ba230a4035 // indirect

--- a/go.sum
+++ b/go.sum
@@ -24,6 +24,8 @@ github.com/muesli/reflow v0.3.0/go.mod h1:pbwTDkVPibjO2kyvBQRBxTWEEGDGq0FlB1BIKt
 github.com/muesli/termenv v0.11.1-0.20220212125758-44cd13922739/go.mod h1:Bd5NYQ7pd+SrtBSrSNoBBmXlcY8+Xj4BMJgh8qcZrvs=
 github.com/muesli/termenv v0.12.0 h1:KuQRUE3PgxRFWhq4gHvZtPSLCGDqM5q/cYr1pZ39ytc=
 github.com/muesli/termenv v0.12.0/go.mod h1:WCCv32tusQ/EEZ5S8oUIIrC/nIuBcxCVqlN4Xfkv+7A=
+github.com/pelletier/go-toml/v2 v2.2.3 h1:YmeHyLY8mFWbdkNWwpr+qIL2bEqT0o95WSdkNHvL12M=
+github.com/pelletier/go-toml/v2 v2.2.3/go.mod h1:MfCQTFTvCcUyyvvwm1+G6H/jORL20Xlb6rzQu9GuUkc=
 github.com/rivo/uniseg v0.1.0/go.mod h1:J6wj4VEh+S6ZtnVlnTBMWIodfgj8LQOQFoIToxlJtxc=
 github.com/rivo/uniseg v0.2.0/go.mod h1:J6wj4VEh+S6ZtnVlnTBMWIodfgj8LQOQFoIToxlJtxc=
 github.com/rivo/uniseg v0.3.4 h1:3Z3Eu6FGHZWSfNKJTOUiPatWwfc7DzJRU04jFUqJODw=

--- a/logger.go
+++ b/logger.go
@@ -1,0 +1,29 @@
+package main
+
+import (
+	"log"
+	"os"
+
+	tea "github.com/charmbracelet/bubbletea"
+)
+
+var logger *log.Logger
+
+type NoOpWriter struct{}
+
+func (w *NoOpWriter) Write(p []byte) (int, error) {
+	return len(p), nil
+}
+
+func SetupLogger() {
+
+	if len(os.Getenv("DEBUG")) > 0 {
+		f, err := tea.LogToFile("debug.log", "debug")
+		if err != nil {
+			log.Fatalf("failed to open log file: %v", err)
+		}
+		logger = log.New(f, "DEBUG: ", log.Ldate|log.Ltime|log.Lshortfile)
+	} else {
+		logger = log.New(&NoOpWriter{}, "", 0)
+	}
+}

--- a/main.go
+++ b/main.go
@@ -163,19 +163,24 @@ func main() {
 		os.Exit(0)
 	}
 
-	config, err := LoadConfig(flag.Args())
-	if err != nil {
-		fmt.Fprintf(os.Stderr, "Config error: %s\n", err)
-		os.Exit(2)
-	}
+	fileConfig, err := LoadConfigFile()
+	// envConfig, err := LoadConfig(flag.Args())
+
 	var initialModel = model{
-		zones:      config.Zones,
+		zones:      fileConfig.Zones,
 		clock:      *NewClock(0),
 		showDates:  false,
 		isMilitary: *military,
 		watch:      *watch,
 		showHelp:   false,
 	}
+
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "Config error: %s\n", err)
+		os.Exit(2)
+	}
+
+	// initialModel.zones = envConfig.Zones
 
 	if *when != 0 {
 		initialModel.clock = *NewClock(*when)

--- a/main.go
+++ b/main.go
@@ -92,43 +92,53 @@ func (m model) Init() tea.Cmd {
 	return tick()
 }
 
+func match(input string, options []string) bool {
+	for _, option := range options {
+		if input == option {
+			return true
+		}
+	}
+	return false
+}
+
 func (m *model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 	switch msg := msg.(type) {
 
 	case tea.KeyMsg:
-		switch msg.String() {
-		case "ctrl+c", "q", "esc":
+		switch {
+
+		case msg.String() == "ctrl+c", msg.String() == "q", msg.String() == "esc":
 			return m, tea.Quit
 
-		case "left", "h":
+		case match(msg.String(), m.keymaps.PrevHour):
 			m.clock.AddHours(-1)
 
-		case "right", "l":
+		case match(msg.String(), m.keymaps.NextHour):
 			m.clock.AddHours(1)
 
-		case "H":
+		case match(msg.String(), m.keymaps.PrevDay):
 			m.clock.AddDays(-1)
 
-		case "L":
+		case match(msg.String(), m.keymaps.NextDay):
 			m.clock.AddDays(1)
 
-		case "<":
+		case match(msg.String(), m.keymaps.PrevWeek):
 			m.clock.AddDays(-7)
 
-		case ">":
+		case match(msg.String(), m.keymaps.NextWeek):
 			m.clock.AddDays(7)
 
-		case "o":
+		case match(msg.String(), m.keymaps.OpenWeb):
 			openInTimeAndDateDotCom(m.clock.Time())
 
-		case "t":
+		case match(msg.String(), m.keymaps.Now):
 			m.clock = *NewClock(0)
 
-		case "?":
-			m.showHelp = !m.showHelp
-
-		case "d":
+		case match(msg.String(), m.keymaps.ToggleDate):
 			m.showDates = !m.showDates
+
+		case msg.String() == "?":
+			m.showHelp = !m.showHelp
 		}
 
 	case tickMsg:

--- a/main.go
+++ b/main.go
@@ -151,6 +151,9 @@ func (m *model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 }
 
 func main() {
+	SetupLogger()
+	logger.Println("Startup")
+
 	exitQuick := flag.Bool("q", false, "exit immediately")
 	showVersion := flag.Bool("v", false, "show version")
 	when := flag.Int64("when", 0, "time in seconds since unix epoch")

--- a/main.go
+++ b/main.go
@@ -73,6 +73,7 @@ func openInTimeAndDateDotCom(t time.Time) error {
 
 type model struct {
 	zones       []*Zone
+	keymaps     Keymaps
 	clock       Clock
 	showDates   bool
 	interactive bool
@@ -168,6 +169,7 @@ func main() {
 
 	var initialModel = model{
 		zones:      fileConfig.Zones,
+		keymaps:    fileConfig.Keymaps,
 		clock:      *NewClock(0),
 		showDates:  false,
 		isMilitary: *military,

--- a/main.go
+++ b/main.go
@@ -174,12 +174,11 @@ func main() {
 		os.Exit(0)
 	}
 
-	fileConfig, err := LoadConfigFile()
-	// envConfig, err := LoadConfig(flag.Args())
+	config, err := LoadConfig(flag.Args())
 
 	var initialModel = model{
-		zones:      fileConfig.Zones,
-		keymaps:    fileConfig.Keymaps,
+		zones:      config.Zones,
+		keymaps:    config.Keymaps,
 		clock:      *NewClock(0),
 		showDates:  false,
 		isMilitary: *military,
@@ -191,8 +190,6 @@ func main() {
 		fmt.Fprintf(os.Stderr, "Config error: %s\n", err)
 		os.Exit(2)
 	}
-
-	// initialModel.zones = envConfig.Zones
 
 	if *when != 0 {
 		initialModel.clock = *NewClock(*when)

--- a/main_test.go
+++ b/main_test.go
@@ -61,8 +61,9 @@ func TestUpdateIncHour(t *testing.T) {
 
 	for _, test := range tests {
 		m := model{
-			zones: DefaultZones,
-			clock: *NewClock(getTimestampWithHour(test.startHour)),
+			zones:   DefaultZones,
+			keymaps: NewDefaultConfig().Keymaps,
+			clock:   *NewClock(getTimestampWithHour(test.startHour)),
 		}
 
 		db := m.clock.Time().Day()
@@ -103,8 +104,9 @@ func TestUpdateDecHour(t *testing.T) {
 
 	for _, test := range tests {
 		m := model{
-			zones: DefaultZones,
-			clock: *NewClock(getTimestampWithHour(test.startHour)),
+			zones:   DefaultZones,
+			keymaps: NewDefaultConfig().Keymaps,
+			clock:   *NewClock(getTimestampWithHour(test.startHour)),
 		}
 		nextState, cmd := m.Update(msg)
 		if cmd != nil {

--- a/view.go
+++ b/view.go
@@ -88,14 +88,28 @@ func (m model) View() string {
 	return s
 }
 
-func status(m model) string {
+// Generate the string
+func generateKeymapString(k Keymaps) string {
+	return fmt.Sprintf(", %s/%s: hours, %s/%s: days, %s/%s: weeks, %s: toggle date, %s: now, %s: open in web",
+		// Only use the first of each mapping
+		k.PrevHour[0], k.NextHour[0],
+		k.PrevDay[0], k.NextDay[0],
+		k.PrevWeek[0], k.NextWeek[0],
+		k.ToggleDate[0],
+		k.Now[0],
+		k.OpenWeb[0],
+	)
+}
 
+func status(m model) string {
 	var text string
 
+	helpPrefix := "  q: quit, ?: help"
+
 	if m.showHelp {
-		text = "  q: quit, ?: help, h/l: hours, H/L: days, </>: weeks, d: toggle date, t: now, o: open in web"
+		text = helpPrefix + generateKeymapString(m.keymaps)
 	} else {
-		text = "  q: quit, ?: help"
+		text = helpPrefix
 	}
 
 	for {


### PR DESCRIPTION
Allow specifying configuration through a toml configuration file, such as `~/.config/tz/conf.toml`.

Configurations are applied in this order, overriding at each subsequent step:

1. Configuration file `~/.config/tz/conf.toml`
2. Environment variable `TZ_LIST`
3. Command line arguments `tz UTC`

Example configuration:

```toml
[[zones]]
id = "NZ"
name = "NZ"

[[zones]]
id = "Australia/Sydney"
name = "Sydney"

[[zones]]
id = "Asia/Kolkata"
name = "Bangalore"

[[zones]]
id = "UTC"
name = "UTC"

[keymaps]
prev_hour = ["h", "left"]
next_hour = ["l", "right"]
prev_day = ["k", "up"]
next_day = ["j", "down"]
prev_week = ["p", "<"]
next_week = ["n", ">"]
toggle_date = ["d"]
open_web = ["o", "x"]
now = ["t"]
```

Additional

- Debug logger with `DEBUG=1 tz`

To do:

- [x] Defaults
- [x] Merge or prioritize Env Config over File Config
- [x] Documentation
- [x] Tests